### PR TITLE
Fix remove log

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelata/node-fire",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Modelata abstract layer for firebase-admin sdk in node.js",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/mf-dao.ts
+++ b/src/mf-dao.ts
@@ -354,10 +354,6 @@ export abstract class MFDao<M extends MFModel<M>> implements IMFDao<M> {
         }
       );
     }
-    MFLogger.error(
-      '[firestoreDao] - getNewModelFromDb return null because dbObj.exists is null or false. dbObj :',
-      snapshot
-    );
     return null;
   }
 


### PR DESCRIPTION
The removed log spams the backend.
The best way to get rid of the logs would be to check if snapshot.exists before try to red its data (which triggers the log in node-fire but not its sibling, angular-fire), but the functions is only explicitly called via cloud functions and stats api so this is a workaround.
Once published, the test would be to update the version of this lib in the backend and see that the logs are gone.